### PR TITLE
Amend guidance link to point to BT & add "...and young people" to "..children" text

### DIFF
--- a/app/views/allocation_request_forms/new.html.haml
+++ b/app/views/allocation_request_forms/new.html.haml
@@ -10,8 +10,8 @@
   = render partial: 'shared/user_form', locals: { form: f }
 
   = f.govuk_fieldset legend: { text: 'About the eligible young people' } do
-    = f.govuk_number_field :number_eligible, required: true, width: 'one-quarter', label: { text: 'Total number of children eligible for increased internet access' }
+    = f.govuk_number_field :number_eligible, required: true, width: 'one-quarter', label: { text: 'Total number of children and young people eligible for increased internet access' }
     = f.govuk_number_field :number_eligible_with_hotspot_access, required: true,  width: 'one-quarter',
-                          label: { text: 'Total number of eligible children who can access a BT hotspot' },
+                          label: { text: 'Total number of eligible children and young people who can access a BT hotspot' },
                           hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe
   = f.govuk_submit

--- a/app/views/allocation_request_forms/new.html.haml
+++ b/app/views/allocation_request_forms/new.html.haml
@@ -13,5 +13,5 @@
     = f.govuk_number_field :number_eligible, required: true, width: 'one-quarter', label: { text: 'Total number of children eligible for increased internet access' }
     = f.govuk_number_field :number_eligible_with_hotspot_access, required: true,  width: 'one-quarter',
                           label: { text: 'Total number of eligible children who can access a BT hotspot' },
-                          hint_text: 'See our guidance on <a href="#todo">how to check access to hotspots</a>'.html_safe
+                          hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe
   = f.govuk_submit

--- a/app/views/application_forms/new.html.haml
+++ b/app/views/application_forms/new.html.haml
@@ -18,7 +18,7 @@
                                       :id,
                                       :name,
                                       inline: true,
-                                      hint_text: 'See our guidance on <a href="#todo">how to check access to hotspots</a>'.html_safe,
+                                      hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
                                       legend: { text: 'Can the child or young person access a BT hotspot?' }
 
     = f.govuk_radio_buttons_fieldset :is_account_holder, legend: { text: 'Who is the account holder for the mobile device?' } do


### PR DESCRIPTION
### Context

Amend guidance link to point to BT & add "...and young people" to "..children" text, on advice from content designer

### Changes proposed in this pull request

### Guidance to review

