### PR TITLE
add guidance page and make it the default route

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,6 +45,9 @@
           <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+              <li class="govuk-header__navigation-item govuk-header__navigation-item<%= request.path == '/pages/guidance' ? "--active" : "" %>">
+                <%= link_to "Guidance", '/pages/guidance', class: "govuk-header__link" %>
+              </li>
               <li class="govuk-header__navigation-item govuk-header__navigation-item<%= request.path == new_allocation_request_form_path ? "--active" : "" %>">
                 <%= link_to "Tell us how many eligible young people you know about", new_allocation_request_form_path, class: "govuk-header__link" %>
               </li>

--- a/app/views/pages/guidance.html.haml
+++ b/app/views/pages/guidance.html.haml
@@ -1,0 +1,50 @@
+%h1.govuk-heading-xl
+  Improving children’s internet access
+
+%p.govuk-body-l
+  We know internet access supports remote learning, as well as virtual meetings between children and their social workers. We also know some children don’t have reliable internet access.
+
+%p.govuk-body
+  The Department for Education has teamed up with BT to give young people free access to BT wifi hotspots. BT will create a set of profiles that young people can activate through name/password combinations.
+
+%p.govuk-body
+  By increasing internet access in this way, children and young people can still learn at home or meet their social workers virtually without running up data charges.
+
+%h2.govuk-heading-l
+  Who’s eligible for free wifi
+
+%p.govuk-body
+  Free wifi is available to children from early years up to 16, and care leavers up to 25 if they:
+
+%ul.govuk-list.govuk-list--bullet
+  %li
+    don’t have access to a fixed broadband connection
+  %li
+    cannot afford the additional data needed to access educational resources or social care services
+
+%h2.govuk-heading-l
+  How young people can get profile details
+
+%p.govuk-body
+  The Department for Education has allocated a number of profiles to local authorities based on school census data.
+
+%p.govuk-body
+  Once local authorities confirm they want these, they’ll receive profile details which they can pass on to schools to distribute.
+
+%p.govuk-body
+  Schools should only distribute the profiles to eligible young people who have access to BT hotspots.
+
+%p.govuk-body
+  If local authorities think their initial allocation isn’t sufficient, they can request more.
+
+%h2.govuk-heading-l
+  There’s technical support
+
+%p.govuk-body
+  BT are offering support to young people using the hotspots. [Not sure what we’re saying here.]
+
+%h2.govuk-heading-l
+  For young people who can’t connect to BT hotspots
+
+%p.govuk-body
+  The Department for Education is still considering how to support young people who can’t connect to a BT hotspot. One possible solution is increasing data allowances on young people’s mobile devices so they can access the internet without incurring data charges. We’ll let you know more about this when we get more information.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
   get '/422', to: 'errors#unprocessable_entity', via: :all
   get '/500', to: 'errors#internal_server_error', via: :all
 
-  get '/', to: redirect('allocation_request_forms/new')
+  get '/', to: redirect('pages/guidance')
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Add guidance page and make it the default route

### Guidance to review

From the root url, you should now see the guidance page, and an active link in the navbar for 'guidance'
<img width="1146" alt="Screen Shot 2020-05-28 at 16 15 18" src="https://user-images.githubusercontent.com/134501/83159935-78f9de00-a0fe-11ea-874b-98809f264200.png">

