### PR TITLE
Stop duplicate users being created 

### DIFF
--- a/app/concerns/inline_user.rb
+++ b/app/concerns/inline_user.rb
@@ -10,7 +10,12 @@ module InlineUser
   private
 
     def construct_user
-      User.new(full_name: @user_name, email_address: @user_email, organisation: @user_organisation)
+      User.where(email_address: @user_email).first ||
+        User.new(full_name: @user_name, email_address: @user_email, organisation: @user_organisation)
+    end
+
+    def retrieve_user_by_email(email)
+      User.where(email_address: email).first
     end
 
     def populate_from_user!

--- a/app/controllers/allocation_request_forms_controller.rb
+++ b/app/controllers/allocation_request_forms_controller.rb
@@ -7,7 +7,8 @@ class AllocationRequestFormsController < ApplicationController
     @allocation_request_form = AllocationRequestForm.new(user: @user, params: allocation_request_form_params)
     begin
       @allocation_request_form.save!
-      save_user_to_session! unless session[:user_id] == @user.id
+      @user = @allocation_request_form.user
+      save_user_to_session!
       redirect_to allocation_request_form_success_path(@allocation_request_form.allocation_request.id)
     rescue ActiveModel::ValidationError
       render :new, status: :bad_request

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,11 +9,7 @@ private
     @user ||= User.new
   end
 
-  def save_user_to_session!
-    session[:user_id] ||= @user.id if @user.present?
-  end
-
-  def build_user(user_params)
-    User.new(user_params)
+  def save_user_to_session!(user = @user)
+    session[:user_id] ||= user.id if user.present?
   end
 end

--- a/app/controllers/application_forms_controller.rb
+++ b/app/controllers/application_forms_controller.rb
@@ -8,7 +8,8 @@ class ApplicationFormsController < ApplicationController
     @application_form = ApplicationForm.new(user: @user, params: application_form_params)
     begin
       @application_form.save!
-      save_user_to_session! unless session[:user_id] == @user.id
+      @user = @application_form.user
+      save_user_to_session!
       redirect_to application_form_success_path(@application_form.recipient.id)
     rescue ActiveModel::ValidationError
       @mobile_networks = MobileNetwork.order('LOWER(brand)')

--- a/app/form_objects/application_form.rb
+++ b/app/form_objects/application_form.rb
@@ -36,7 +36,9 @@ class ApplicationForm
   end
 
   def save!
-    @user ||= construct_user
+    unless @user.try(:persisted?)
+      @user = retrieve_user_by_email(@user.email_address) || construct_user
+    end
     @recipient ||= construct_recipient
     validate!
     @user.save!

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -43,6 +43,13 @@ RSpec.feature 'Session behaviour', type: :feature do
       click_on 'Sign out'
       expect(page).to have_text('Sign in')
     end
+
+    scenario 'submitting a valid form with an existing user email address does not create a duplicate user' do
+      user = create(:local_authority_user)
+      visit new_application_form_path
+      fill_in_valid_application_form(user_email: user.email_address, mobile_network_name: participating_mobile_network.brand)
+      expect { click_on 'Continue' }.not_to change(User, :count)
+    end
   end
 
   context 'with a valid user' do

--- a/spec/shared/filling_in_forms.rb
+++ b/spec/shared/filling_in_forms.rb
@@ -1,6 +1,6 @@
-def fill_in_valid_application_form(mobile_network_name: 'Participating mobile network')
+def fill_in_valid_application_form(user_email: 'validmail@localauthority.gov.uk', mobile_network_name: 'Participating mobile network')
   fill_in 'Your full name', with: 'Bob Boberts'
-  fill_in 'Your email address', with: 'validmail@localauthority.gov.uk'
+  fill_in 'Your email address', with: user_email
   fill_in 'Name of the organisation you work for', with: 'A Local Authority'
 
   fill_in 'Name of the eligible child or young person', with: 'young person'


### PR DESCRIPTION
### Context

There's an edge case in the session/form handling that means if you submit multiple forms with the same email address, multiple users can be created. This PR fixes the issue.

### Changes proposed in this pull request

### Guidance to review

