### PR TITLE
Initial usability tweaks

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def browser_title
+    page_browser_title = content_for(:browser_title).presence || content_for(:title)
+    [page_browser_title, t('service_name'), 'GOV.UK'].select(&:present?).join(' - ')
+  end
+
   def yes_no_options
     [
       OpenStruct.new(id: 'yes', name: 'Yes'),

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -13,6 +13,10 @@ module ViewHelper
     link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
   end
 
+  def title_with_error_prefix(title, error)
+    "#{t('page_titles.error_prefix') if error}#{title}"
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,0 +1,25 @@
+module ViewHelper
+  def govuk_link_to(body, url, html_options = {}, &_block)
+    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
+
+    return link_to(url, html_options) { yield } if block_given?
+
+    link_to(body, url, html_options)
+  end
+
+  def govuk_button_link_to(body, url, html_options = {})
+    html_options[:class] = prepend_css_class('govuk-button', html_options[:class])
+
+    link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
+  end
+
+private
+
+  def prepend_css_class(css_class, current_class)
+    if current_class
+      current_class.prepend("#{css_class} ")
+    else
+      css_class
+    end
+  end
+end

--- a/app/views/allocation_request_forms/new.html.erb
+++ b/app/views/allocation_request_forms/new.html.erb
@@ -23,7 +23,7 @@
                                   required: true,
                                   width: 'one-quarter',
                                   label: { text: 'Total number of eligible children and young people who can access a BT hotspot' },
-                                  hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
+                                  hint_text: 'There’s guidance available on <a class="govuk-link" href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
                                   min: 0,
                                   max: 10000,
                                   step: 1 %>

--- a/app/views/allocation_request_forms/new.html.erb
+++ b/app/views/allocation_request_forms/new.html.erb
@@ -1,7 +1,9 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.eligible_people'), @allocation_request_form.errors.any?) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Tell us how many eligible young people you know about
+      <%= t('page_titles.eligible_people') %>
     </h1>
     <p class="govuk-body-l">
       Please complete all the fields you can.

--- a/app/views/allocation_request_forms/new.html.erb
+++ b/app/views/allocation_request_forms/new.html.erb
@@ -1,30 +1,34 @@
-<h1 class="govuk-heading-xl">
-  Tell us how many eligible young people you know about
-</h1>
-<p class="govuk-body-l">
-  Please complete all the fields you can.
-</p>
-<%= form_for @allocation_request_form do |f| %>
-  <%= f.govuk_error_summary %>
-  <%= f.fields_for :user do |user_form| %>
-    <%= render partial: 'shared/user_form', locals: { form: f } %>
-  <% end %>
-  <%= f.govuk_fieldset legend: { text: 'About the eligible young people' } do %>
-    <%= f.govuk_number_field :number_eligible,
-                              required: true,
-                              width: 'one-quarter',
-                              label: { text: 'Total number of children and young people eligible for increased internet access' },
-                              min: 0,
-                              max: 10000,
-                              step: 1 %>
-    <%= f.govuk_number_field :number_eligible_with_hotspot_access,
-                              required: true,
-                              width: 'one-quarter',
-                              label: { text: 'Total number of eligible children and young people who can access a BT hotspot' },
-                              hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
-                              min: 0,
-                              max: 10000,
-                              step: 1 %>
-  <% end %>
-  <%= f.govuk_submit %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Tell us how many eligible young people you know about
+    </h1>
+    <p class="govuk-body-l">
+      Please complete all the fields you can.
+    </p>
+    <%= form_for @allocation_request_form do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.fields_for :user do |user_form| %>
+        <%= render partial: 'shared/user_form', locals: { form: f } %>
+      <% end %>
+      <%= f.govuk_fieldset legend: { text: 'About the eligible young people' } do %>
+        <%= f.govuk_number_field :number_eligible,
+                                  required: true,
+                                  width: 'one-quarter',
+                                  label: { text: 'Total number of children and young people eligible for increased internet access' },
+                                  min: 0,
+                                  max: 10000,
+                                  step: 1 %>
+        <%= f.govuk_number_field :number_eligible_with_hotspot_access,
+                                  required: true,
+                                  width: 'one-quarter',
+                                  label: { text: 'Total number of eligible children and young people who can access a BT hotspot' },
+                                  hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
+                                  min: 0,
+                                  max: 10000,
+                                  step: 1 %>
+      <% end %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/allocation_request_forms/success.html.erb
+++ b/app/views/allocation_request_forms/success.html.erb
@@ -6,11 +6,15 @@
     Your information has been received successfully
   </div>
 </div>
-<h2 class="govuk-heading-m">
-  What happens next
-</h2>
-<p class="govuk-body">
-  We will contact you on the email address you provided (
-  <%= @allocation_request_form.user.email_address %>
-  ) soon.
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+    <p class="govuk-body">
+      We will contact you on the email address you provided (
+      <%= @allocation_request_form.user.email_address %>
+      ) soon.
+    </p>
+  </div>
+</div>

--- a/app/views/allocation_request_forms/success.html.erb
+++ b/app/views/allocation_request_forms/success.html.erb
@@ -1,6 +1,8 @@
+<% content_for :title, t('page_titles.thank_you') %>
+
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
-    Thank you
+    <%= t('page_titles.thank_you') %>
   </h1>
   <div class="govuk-panel__body">
     Your information has been received successfully

--- a/app/views/application_forms/new.html.erb
+++ b/app/views/application_forms/new.html.erb
@@ -1,7 +1,9 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.eligible_person'), @application_form.errors.any?) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Tell us about an eligible young person
+      <%= t('page_titles.eligible_person') %>
     </h1>
 
     <p class="govuk-body-l">

--- a/app/views/application_forms/new.html.erb
+++ b/app/views/application_forms/new.html.erb
@@ -1,68 +1,72 @@
-<h1 class="govuk-heading-xl">
-  Tell us about an eligible young person
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Tell us about an eligible young person
+    </h1>
 
-<p class="govuk-body-l">
-  Please complete all the fields you can.
-</p>
+    <p class="govuk-body-l">
+      Please complete all the fields you can.
+    </p>
 
-<%= form_for @application_form do |f| %>
-  <%= f.govuk_error_summary %>
+    <%= form_for @application_form do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <%= render partial: 'shared/user_form', locals: { form: f } %>
+      <%= render partial: 'shared/user_form', locals: { form: f } %>
 
-  <%= f.govuk_fieldset legend: { text: 'About the recipient' } do %>
-    <%= f.govuk_text_field :full_name, required: true, label: { text: 'Name of the eligible child or young person' } %>
-    <%= f.govuk_text_area  :address, required: true, rows: 3, label: { text: 'Address of the child or young person' } %>
-    <%= f.govuk_text_field :postcode, required: true, width: 'one-quarter', label: { text: 'Postcode of the child or young person' } %>
-    <%= f.govuk_collection_radio_buttons :can_access_hotspot,
-                                      yes_no_options,
-                                      :id,
-                                      :name,
-                                      inline: true,
-                                      hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
-                                      legend: { text: 'Can the child or young person access a BT hotspot?' }  %>
+      <%= f.govuk_fieldset legend: { text: 'About the recipient' } do %>
+        <%= f.govuk_text_field :full_name, required: true, label: { text: 'Name of the eligible child or young person' } %>
+        <%= f.govuk_text_area  :address, required: true, rows: 3, label: { text: 'Address of the child or young person' } %>
+        <%= f.govuk_text_field :postcode, required: true, width: 'one-quarter', label: { text: 'Postcode of the child or young person' } %>
+        <%= f.govuk_collection_radio_buttons :can_access_hotspot,
+                                          yes_no_options,
+                                          :id,
+                                          :name,
+                                          inline: true,
+                                          hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
+                                          legend: { text: 'Can the child or young person access a BT hotspot?' }  %>
 
-    <%= f.govuk_radio_buttons_fieldset :is_account_holder, legend: { text: 'Who is the account holder for the mobile device?' } do %>
-      <%= f.govuk_radio_button :is_account_holder, 'yes', label: { text: 'Child/young person' } %>
-      <%= f.govuk_radio_button :is_account_holder, 'no', label: { text: 'Parent/guardian' } do %>
-        <%= f.govuk_text_field :account_holder_name, label: { text: 'Please give the name of the account holder ' } %>
+        <%= f.govuk_radio_buttons_fieldset :is_account_holder, legend: { text: 'Who is the account holder for the mobile device?' } do %>
+          <%= f.govuk_radio_button :is_account_holder, 'yes', label: { text: 'Child/young person' } %>
+          <%= f.govuk_radio_button :is_account_holder, 'no', label: { text: 'Parent/guardian' } do %>
+            <%= f.govuk_text_field :account_holder_name, label: { text: 'Please give the name of the account holder ' } %>
+          <%- end %>
+        <%- end %>
+        <%= f.govuk_phone_field :device_phone_number, required: true, label: { text: 'Phone number of device' } %>
+
+        <%= f.govuk_collection_select :mobile_network_id,
+                                    @mobile_networks,
+                                    :id,
+                                    :brand,
+                                    label: { text: 'Name of phone network' }  %>
+
+        <%= f.govuk_collection_radio_buttons :privacy_statement_sent_to_family,
+                                          yes_no_options,
+                                          :id,
+                                          :name,
+                                          inline: true,
+                                          legend: { text: 'Has the privacy statement been sent to the family?' } %>
+
+
+        <%= f.govuk_collection_radio_buttons :understands_how_pii_will_be_used,
+                                          yes_no_options,
+                                          :id,
+                                          :name,
+                                          inline: true,
+                                          legend: { text: 'Does the child/family understand how their personal information will be used?' } %>
       <%- end %>
-    <%- end %>
-    <%= f.govuk_phone_field :device_phone_number, required: true, label: { text: 'Phone number of device' } %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">
+          !
+        </span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">
+            Warning
+          </span>
+          Once you submit this form, we’ll pass on the information to mobile network operators.
+        </strong>
+      </div>
 
-    <%= f.govuk_collection_select :mobile_network_id,
-                                @mobile_networks,
-                                :id,
-                                :brand,
-                                label: { text: 'Name of phone network' }  %>
-
-    <%= f.govuk_collection_radio_buttons :privacy_statement_sent_to_family,
-                                      yes_no_options,
-                                      :id,
-                                      :name,
-                                      inline: true,
-                                      legend: { text: 'Has the privacy statement been sent to the family?' } %>
-
-
-    <%= f.govuk_collection_radio_buttons :understands_how_pii_will_be_used,
-                                      yes_no_options,
-                                      :id,
-                                      :name,
-                                      inline: true,
-                                      legend: { text: 'Does the child/family understand how their personal information will be used?' } %>
-  <%- end %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">
-      !
-    </span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">
-        Warning
-      </span>
-      Once you submit this form, we’ll pass on the information to mobile network operators.
-    </strong>
+      <%= f.govuk_submit %>
+    <% end %>
   </div>
-
-  <%= f.govuk_submit %>
-<% end %>
+</div>

--- a/app/views/application_forms/new.html.erb
+++ b/app/views/application_forms/new.html.erb
@@ -22,7 +22,7 @@
                                           :id,
                                           :name,
                                           inline: true,
-                                          hint_text: 'There\'s guidance available on <a href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
+                                          hint_text: 'There’s guidance available on <a class="govuk-link" href="https://www.btwifi.com/find/ ">how to check access to hotspots</a>'.html_safe,
                                           legend: { text: 'Can the child or young person access a BT hotspot?' }  %>
 
         <%= f.govuk_radio_buttons_fieldset :is_account_holder, legend: { text: 'Who is the account holder for the mobile device?' } do %>

--- a/app/views/application_forms/success.html.erb
+++ b/app/views/application_forms/success.html.erb
@@ -1,6 +1,8 @@
+<% content_for :title, t('page_titles.thank_you') %>
+
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
-    Thank you
+    <%= t('page_titles.thank_you') %>
   </h1>
   <div class="govuk-panel__body">
     Your information has been received successfully

--- a/app/views/application_forms/success.html.erb
+++ b/app/views/application_forms/success.html.erb
@@ -6,14 +6,18 @@
     Your information has been received successfully
   </div>
 </div>
-<h2 class="govuk-heading-m">
-  What happens next
-</h2>
-<p class="govuk-body">
-  We will contact you on the email address you provided (
-  <%= @application_form.user.email_address %>
-  ) soon.
-</p>
-<p class="govuk-body">
-  <%= link_to 'Tell us about another child or young person', new_application_form_path %>
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+    <p class="govuk-body">
+      We will contact you on the email address you provided (
+      <%= @application_form.user.email_address %>
+      ) soon.
+    </p>
+    <p class="govuk-body">
+      <%= link_to 'Tell us about another child or young person', new_application_form_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/application_forms/success.html.erb
+++ b/app/views/application_forms/success.html.erb
@@ -17,7 +17,7 @@
       ) soon.
     </p>
     <p class="govuk-body">
-      <%= link_to 'Tell us about another child or young person', new_application_form_path %>
+      <%= govuk_link_to 'Tell us about another child or young person', new_application_form_path %>
     </p>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Improving internet access for children without broadband at home</title>
+    <title><%= try(:browser_title) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,68 +1,72 @@
-<h1 class="govuk-heading-xl">
-  Improving children’s internet access
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Improving children’s internet&nbsp;access
+    </h1>
 
-<p class="govuk-body-l">
-  We know internet access supports remote education, as well as virtual meetings between children and their social workers. That’s why we’re providing laptops, tablets and 4G wireless routers to disadvantaged families. (There’s more about this on <%= link_to 'GOV.UK.', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>)
-</p>
-<p class="govuk-body-l">
-  We also know some children don’t have reliable internet access. That’s why we’re now acting to change this.
-</p>
-<h2 class="govuk-heading-l">
-  How we’re improving children’s internet access
-</h2>
-<p class="govuk-body">
-  The Department for Education has teamed up with BT and mobile network operators to improve children’s internet access in two different ways:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>
-    We’re giving them free access to BT wifi hotspots. BT will create a set of profiles that young people can activate through name/password combinations.
-  </li>
-  <li>
-    For anyone who can’t connect to a BT hotspot, we plan to boost data allowances on their mobile devices so they can access the internet without incurring data charges.
-  </li>
-</ul>
-<h2 class="govuk-heading-l">
-  Who can get help
-</h2>
-<p class="govuk-body">
-  Increased internet access is available to children from early years up to 16, and care leavers up to 25 if they:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>
-    don’t have access to a <%= link_to 'fixed broadband connection', 'https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/advice/broadband-speeds/broadband-basics' %>
-  </li>
-  <li>
-    cannot afford the additional data needed to access educational resources or social care services
-  </li>
-</ul>
-<h2 class="govuk-heading-l">
-  Accessing BT hotspots
-</h2>
-<p class="govuk-body">
-  The Department for Education has allocated a number of BT hotspot profiles to trusts and local authorities.
-</p>
-<p class="govuk-body">
-  Once trusts and local authorities confirm they want these, they’ll receive profile details which they can pass on to schools to distribute.
-</p>
-<p class="govuk-body">
-  Schools should only distribute the profiles to eligible young people who have access to BT hotspots.
-</p>
-<p class="govuk-body">
-  If trusts and local authorities think their initial allocation isn’t sufficient, they can request more.
-</p>
-<h2 class="govuk-heading-l">
-  There’s technical support
-</h2>
-<p class="govuk-body">
-  BT are offering technical support to young people using the hotspots.
-</p>
-<p class="govuk-body">
-  Their free help desk is open from 8am until 8pm on 0800 587 9983.
-</p>
-<h2 class="govuk-heading-l">
-  For young people who can’t connect to BT hotspots
-</h2>
-<p class="govuk-body">
-  We want to support young people who can’t connect to a BT hotspot. One possible solution is increasing data allowances on young people’s mobile devices so they can access the internet without incurring data charges. There will be more information about this once we confirm our plans.
-</p>
+    <p class="govuk-body-l">
+      We know internet access supports remote education, as well as virtual meetings between children and their social workers. That’s why we’re providing laptops, tablets and 4G wireless routers to disadvantaged families. (There’s more about this on <%= link_to 'GOV.UK', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>.)
+    </p>
+    <p class="govuk-body-l">
+      We also know some children don’t have reliable internet access. That’s why we’re now acting to change this.
+    </p>
+    <h2 class="govuk-heading-l">
+      How we’re improving children’s internet access
+    </h2>
+    <p class="govuk-body">
+      The Department for Education has teamed up with BT and mobile network operators to improve children’s internet access in two different ways:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        We’re giving them free access to BT wifi hotspots. BT will create a set of profiles that young people can activate through name/password combinations.
+      </li>
+      <li>
+        For anyone who can’t connect to a BT hotspot, we plan to boost data allowances on their mobile devices so they can access the internet without incurring data charges.
+      </li>
+    </ul>
+    <h2 class="govuk-heading-l">
+      Who can get help
+    </h2>
+    <p class="govuk-body">
+      Increased internet access is available to children from early years up to 16, and care leavers up to 25 if they:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        don’t have access to a <%= link_to 'fixed broadband connection', 'https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/advice/broadband-speeds/broadband-basics' %>
+      </li>
+      <li>
+        cannot afford the additional data needed to access educational resources or social care services
+      </li>
+    </ul>
+    <h2 class="govuk-heading-l">
+      Accessing BT hotspots
+    </h2>
+    <p class="govuk-body">
+      The Department for Education has allocated a number of BT hotspot profiles to trusts and local authorities.
+    </p>
+    <p class="govuk-body">
+      Once trusts and local authorities confirm they want these, they’ll receive profile details which they can pass on to schools to distribute.
+    </p>
+    <p class="govuk-body">
+      Schools should only distribute the profiles to eligible young people who have access to BT hotspots.
+    </p>
+    <p class="govuk-body">
+      If trusts and local authorities think their initial allocation isn’t sufficient, they can request more.
+    </p>
+    <h2 class="govuk-heading-l">
+      There’s technical support
+    </h2>
+    <p class="govuk-body">
+      BT are offering technical support to young people using the hotspots.
+    </p>
+    <p class="govuk-body">
+      Their free help desk is open from 8am until 8pm on 0800 587 9983.
+    </p>
+    <h2 class="govuk-heading-l">
+      For young people who can’t connect to BT hotspots
+    </h2>
+    <p class="govuk-body">
+      We want to support young people who can’t connect to a BT hotspot. One possible solution is increasing data allowances on young people’s mobile devices so they can access the internet without incurring data charges. There will be more information about this once we confirm our plans.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body-l">
-      We know internet access supports remote education, as well as virtual meetings between children and their social workers. That’s why we’re providing laptops, tablets and 4G wireless routers to disadvantaged families. (There’s more about this on <%= link_to 'GOV.UK', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>.)
+      We know internet access supports remote education, as well as virtual meetings between children and their social workers. That’s why we’re providing laptops, tablets and 4G wireless routers to disadvantaged families. (There’s more about this on <%= govuk_link_to 'GOV.UK', 'https://www.gov.uk/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19' %>.)
     </p>
     <p class="govuk-body-l">
       We also know some children don’t have reliable internet access. That’s why we’re now acting to change this.
@@ -32,7 +32,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        don’t have access to a <%= link_to 'fixed broadband connection', 'https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/advice/broadband-speeds/broadband-basics' %>
+        don’t have access to a <%= govuk_link_to 'fixed broadband connection', 'https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/advice/broadband-speeds/broadband-basics' %>
       </li>
       <li>
         cannot afford the additional data needed to access educational resources or social care services

--- a/app/views/sign_in_tokens/create.html.erb
+++ b/app/views/sign_in_tokens/create.html.erb
@@ -1,19 +1,23 @@
-<h1 class="govuk-heading-xl">
-  Check your email
-</h1>
-<p class="govuk-body">
-  If we've recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.
-</p>
-<div class="govuk-inset-text">
-  <p>
-    If this email hasn't arrived within 5 minutes:
-  </p>
-  <ul class="govuk-list-bullet">
-    <li>
-      Check your spam/junk folder
-    </li>
-    <li>
-      <%= link_to 'Try again', new_sign_in_token_path %>
-    </li>
-  </ul>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Check your email
+    </h1>
+    <p class="govuk-body">
+      If we've recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.
+    </p>
+    <div class="govuk-inset-text">
+      <p>
+        If this email hasn't arrived within 5 minutes:
+      </p>
+      <ul class="govuk-list-bullet">
+        <li>
+          Check your spam/junk folder
+        </li>
+        <li>
+          <%= link_to 'Try again', new_sign_in_token_path %>
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>

--- a/app/views/sign_in_tokens/create.html.erb
+++ b/app/views/sign_in_tokens/create.html.erb
@@ -4,18 +4,18 @@
       Check your email
     </h1>
     <p class="govuk-body">
-      If we've recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.
+      If we’ve recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.
     </p>
     <div class="govuk-inset-text">
       <p>
-        If this email hasn't arrived within 5 minutes:
+        If this email hasn’t arrived within 5 minutes:
       </p>
       <ul class="govuk-list-bullet">
         <li>
           Check your spam/junk folder
         </li>
         <li>
-          <%= link_to 'Try again', new_sign_in_token_path %>
+          <%= govuk_link_to 'Try again', new_sign_in_token_path %>
         </li>
       </ul>
     </div>

--- a/app/views/sign_in_tokens/create.html.erb
+++ b/app/views/sign_in_tokens/create.html.erb
@@ -1,7 +1,9 @@
+<% content_for :title, t('page_titles.check_your_email') %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Check your email
+      <%= t('page_titles.check_your_email') %>
     </h1>
     <p class="govuk-body">
       If we’ve recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.

--- a/app/views/sign_in_tokens/new.html.erb
+++ b/app/views/sign_in_tokens/new.html.erb
@@ -1,8 +1,12 @@
-<h1 class="govuk-heading-xl">
-  Sign in
-</h1>
-<%= form_for @sign_in_token_form, url: sign_in_tokens_path, method: :POST do |f| %>
-  <%= f.govuk_error_summary %>
-  <%= f.govuk_email_field :email_address, required: true, label: { text: 'Please enter your email address' } %>
-  <%= f.govuk_submit %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Sign in
+    </h1>
+    <%= form_for @sign_in_token_form, url: sign_in_tokens_path, method: :POST do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_email_field :email_address, required: true, label: { text: 'Please enter your email address' } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sign_in_tokens/new.html.erb
+++ b/app/views/sign_in_tokens/new.html.erb
@@ -1,7 +1,9 @@
+<% content_for :title, t('page_titles.sign_in') %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Sign in
+      <%= t('page_titles.sign_in') %>
     </h1>
     <%= form_for @sign_in_token_form, url: sign_in_tokens_path, method: :POST do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/sign_in_tokens/token_not_recognised.html.erb
+++ b/app/views/sign_in_tokens/token_not_recognised.html.erb
@@ -1,17 +1,21 @@
-<h1 class="govuk-heading-xl">
-  Sorry, that didn't work
-</h1>
-<p class="govuk-body-l">
-  We didn't recognise that link.
-</p>
-<p class="govuk-body">
-  If you clicked on the link from an email, you could try copying the two special values from your email into here:
-</p>
-<%= form_for @sign_in_token_form, url: validate_manually_entered_sign_in_token_path, method: :get do |f| %>
-  <%= f.govuk_text_field :token %>
-  <%= f.govuk_text_field :identifier %>
-  <%= f.govuk_submit %>
-<% end %>
-<p class="govuk-body">
-  Or <%= link_to 'send a new email', new_sign_in_token_path %>
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Sorry, that didn't work
+    </h1>
+    <p class="govuk-body-l">
+      We didn't recognise that link.
+    </p>
+    <p class="govuk-body">
+      If you clicked on the link from an email, you could try copying the two special values from your email into here:
+    </p>
+    <%= form_for @sign_in_token_form, url: validate_manually_entered_sign_in_token_path, method: :get do |f| %>
+      <%= f.govuk_text_field :token %>
+      <%= f.govuk_text_field :identifier %>
+      <%= f.govuk_submit %>
+    <% end %>
+    <p class="govuk-body">
+      Or <%= link_to 'send a new email', new_sign_in_token_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/sign_in_tokens/token_not_recognised.html.erb
+++ b/app/views/sign_in_tokens/token_not_recognised.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Sorry, that didn't work
+      Sorry, that didn’t work
     </h1>
     <p class="govuk-body-l">
-      We didn't recognise that link.
+      We didn’t recognise that link.
     </p>
     <p class="govuk-body">
       If you clicked on the link from an email, you could try copying the two special values from your email into here:
@@ -15,7 +15,7 @@
       <%= f.govuk_submit %>
     <% end %>
     <p class="govuk-body">
-      Or <%= link_to 'send a new email', new_sign_in_token_path %>
+      Or <%= govuk_link_to 'send a new email', new_sign_in_token_path %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,36 +1,12 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  service_name: Improving internet access for children without broadband at home
+  page_titles:
+    sign_in: Sign in
+    check_your_email: Check your email
+    eligible_people: Tell us how many eligible young people you know about
+    eligible_person: Tell us about an eligible young person
+    thank_you: Thank you
+    error_prefix: "Error: "
   errors:
     format:
       "'%{attribute}' %{message}"

--- a/spec/features/session_behaviour_spec.rb
+++ b/spec/features/session_behaviour_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Session behaviour', type: :feature do
       fill_in 'Please enter your email address', with: valid_user.email_address
       click_on 'Continue'
 
-      expect(page).to have_text("If we've recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.")
+      expect(page).to have_text('If we’ve recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.')
     end
 
     scenario 'Entering an unrecognised email address is silently ignored' do
@@ -74,7 +74,7 @@ RSpec.feature 'Session behaviour', type: :feature do
       fill_in 'Please enter your email address', with: 'unrecognised@example.com'
       click_on 'Continue'
 
-      expect(page).to have_text("If we've recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.")
+      expect(page).to have_text('If we’ve recognised the email address you entered, you should receive an email soon containing a link you can click on to sign in.')
     end
   end
 end

--- a/spec/features/sign_in_token_behaviour_spec.rb
+++ b/spec/features/sign_in_token_behaviour_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Sign-in token behaviour', type: :feature do
       visit broken_token_url
       expect(page).not_to have_text('Sign out')
       expect(page).to have_http_status(:bad_request)
-      expect(page).to have_text('We didn\'t recognise that link')
+      expect(page).to have_text('We didn’t recognise that link')
     end
 
     scenario 'Visiting an invalid token link allows the user to enter them manually' do


### PR DESCRIPTION
### Context

- Constrain page content to 2/3rds width for readability
- Add page titles (using locale files)
- Use correct link styles
- Port useful helpers from Apply

Ignore whitespace when reviewing.