### PR TITLE
Update service name to "Increasing children’s internet access"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Improving internet access for children without broadband at home", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to t('service_name'), "/", class: "govuk-header__link govuk-header__link--service-name" %>
           <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Improving children’s internet&nbsp;access
+      Increasing children’s internet&nbsp;access
     </h1>
 
     <p class="govuk-body-l">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
-  service_name: Improving internet access for children without broadband at home
+  service_name: Increasing children’s internet access
   page_titles:
     sign_in: Sign in
     check_your_email: Check your email

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.feature 'View pages', type: :feature do
   scenario 'Root URL should be the guidance page' do
     visit '/'
-    expect(page).to have_text 'Improving children’s internet access'
+    expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
   end
 
   scenario 'Navigate to guidance page' do
     visit '/pages/guidance'
 
     expect(page).to have_http_status(:ok)
-    expect(page).to have_text 'Improving children’s internet access'
+    expect(page).to have_selector 'h1', text: 'Increasing children’s internet access'
   end
 end


### PR DESCRIPTION
Spoke to @emmajhf about shortening "Improving internet access for children without broadband at home" and found out "Increasing children’s internet access" has already been agreed. 