### PR TITLE
add FakeDataService for generating test data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Canonical meta tag
 gem 'canonical-rails'
 gem 'dotenv-rails'
+# Having Faker here rather than in dev/test lets us still create
+# fake data in the deployed Docker container
+gem 'faker'
 # Manage multiple processes i.e. web server and webpack
 gem 'foreman'
 gem 'govuk_design_system_formbuilder'
@@ -74,7 +77,6 @@ group :development, :test do
   gem 'brakeman'
   gem 'bundle-audit'
   gem 'factory_bot_rails'
-  gem 'faker'
   gem 'simplecov'
 end
 

--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -1,0 +1,19 @@
+class FakeDataService
+  def self.generate!(recipients: 10, mobile_network_id:)
+    recipients.times do |i|
+      name = Faker::Name.name
+      r = Recipient.create!(
+        full_name: name,
+        device_phone_number: Faker::PhoneNumber.cell_phone,
+        address: [Faker::Address.street_address, Faker::Address.city].join("\n"),
+        postcode: Faker::Address.postcode,
+        can_access_hotspot: true,
+        is_account_holder: true,
+        privacy_statement_sent_to_family: true,
+        understands_how_pii_will_be_used: true,
+        mobile_network_id: mobile_network_id
+      )
+      puts "created #{r.id} - #{r.full_name}"
+    end
+  end
+end

--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -1,6 +1,6 @@
 class FakeDataService
   def self.generate!(recipients: 10, mobile_network_id:)
-    recipients.times do |i|
+    recipients.times do
       name = Faker::Name.name
       r = Recipient.create!(
         full_name: name,
@@ -11,7 +11,7 @@ class FakeDataService
         is_account_holder: true,
         privacy_statement_sent_to_family: true,
         understands_how_pii_will_be_used: true,
-        mobile_network_id: mobile_network_id
+        mobile_network_id: mobile_network_id,
       )
       puts "created #{r.id} - #{r.full_name}"
     end


### PR DESCRIPTION
### Context

Need to setup some fake data in production to pre-populate the MNO interface for demos

### Changes proposed in this pull request

Add services/fake_data_service.rb to generate a given number of recipients for a given mobile_network_id

### Guidance to review

From the console:

`FakeDataService.generate!(mobile_network_id: ....)` will generate 10 recipients for the given mobile network ID.  To generate a different number, pass `recipients: 20` for example

