### PR TITLE
Remove recipient name from mno interface

### DIFF
--- a/app/controllers/mno/recipients_controller.rb
+++ b/app/controllers/mno/recipients_controller.rb
@@ -67,7 +67,7 @@ private
     {
       'id' => :id,
       'mobile_number' => :device_phone_number,
-      'full_name' => :full_name,
+      'account_holder_name' => :account_holder_name,
       'requested' => :created_at,
       'status' => :status,
     }[order_param]

--- a/app/form_objects/application_form.rb
+++ b/app/form_objects/application_form.rb
@@ -87,6 +87,9 @@ private
     @can_access_hotspot = params[:can_access_hotspot]
     @is_account_holder = params[:is_account_holder]
     @account_holder_name = params[:account_holder_name]
+    if @account_holder_name.blank? && @is_account_holder
+      @account_holder_name = @full_name
+    end
     @device_phone_number = params[:device_phone_number]
     @mobile_network_id = params[:mobile_network_id]
     @phone_network_name = params[:phone_network_name]
@@ -101,6 +104,9 @@ private
     @can_access_hotspot = @recipient.can_access_hotspot
     @is_account_holder = @recipient.is_account_holder
     @account_holder_name = @recipient.account_holder_name
+    if @account_holder_name.blank? && @recipient.is_account_holder?
+      @account_holder_name = @recipient.full_name
+    end
     @device_phone_number = @recipient.device_phone_number
     @mobile_network_id = @recipient.mobile_network_id
     @phone_network_name = @recipient.phone_network_name

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -14,14 +14,12 @@ class Recipient < ApplicationRecord
   def self.exportable_attributes
     {
       id: 'ID',
-      full_name: 'Recipient name',
-      is_account_holder: 'Recipient is account holder',
       account_holder_name: 'Account holder name',
       device_phone_number: 'Device phone number',
       created_at: 'Requested',
       updated_at: 'Last updated',
       mobile_network_id: 'Mobile network ID',
-      status: 'Status'
+      status: 'Status',
     }
   end
 end

--- a/app/services/fake_data_service.rb
+++ b/app/services/fake_data_service.rb
@@ -9,10 +9,13 @@ class FakeDataService
         postcode: Faker::Address.postcode,
         can_access_hotspot: true,
         is_account_holder: true,
+        account_holder_name: name,
         privacy_statement_sent_to_family: true,
         understands_how_pii_will_be_used: true,
         mobile_network_id: mobile_network_id,
+        status: Recipient.statuses.values.sample,
       )
+      r.update(created_at: Time.now.utc - rand(500000).seconds)
       puts "created #{r.id} - #{r.full_name}"
     end
   end

--- a/app/views/mno/recipients/_recipient.html.erb
+++ b/app/views/mno/recipients/_recipient.html.erb
@@ -12,7 +12,9 @@
     <%= l(recipient.created_at, format: :short) %>
   </td>
   <td class="govuk-table__cell" class="recipient-status">
-    <%= recipient.translated_enum_value(:status) %>
+    <span class="recipient-status-<%= recipient.status %>">
+      <%= recipient.translated_enum_value(:status) %>
+    </span>
   </td>
   <td class="govuk-table__cell">
     <div class="govuk-form-group">

--- a/app/views/mno/recipients/_recipient.html.erb
+++ b/app/views/mno/recipients/_recipient.html.erb
@@ -6,16 +6,7 @@
     <%= recipient.device_phone_number %>
   </td>
   <td class="govuk-table__cell">
-    <%= recipient.full_name %>
-  </td>
-  <td class="govuk-table__cell">
-    <% if recipient.is_account_holder? %>
-      <em>
-        (recipient)
-      </em>
-    <% else %>
-      <%= recipient.account_holder_name %>
-    <% end %>
+    <%= recipient.account_holder_name %>
   </td>
   <td class="govuk-table__cell">
     <%= l(recipient.created_at, format: :short) %>

--- a/app/views/mno/recipients/index.html.erb
+++ b/app/views/mno/recipients/index.html.erb
@@ -26,10 +26,7 @@
             <%= sortable_table_header( 'Mobile number', :mobile_number ) %>
           </th>
           <th class="govuk-table__header">
-            <%= sortable_table_header( 'Recipient name', :full_name ) %>
-          </th>
-          <th class="govuk-table__header">
-            Account holder
+            <%= sortable_table_header( 'Account holder', :account_holder_name ) %>
           </th>
           <th class="govuk-table__header">
             <%= sortable_table_header( 'Requested', :requested ) %>

--- a/db/migrate/20200616114104_populate_account_holder_name_for_all_recipients.rb
+++ b/db/migrate/20200616114104_populate_account_holder_name_for_all_recipients.rb
@@ -1,0 +1,5 @@
+class PopulateAccountHolderNameForAllRecipients < ActiveRecord::Migration[6.0]
+  def change
+    Recipient.where(is_account_holder: true).update_all('account_holder_name=full_name')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_122544) do
+ActiveRecord::Schema.define(version: 2020_06_16_114104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/recipients.rb
+++ b/spec/factories/recipients.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     postcode                          { 'SOM3 T0WN' }
     can_access_hotspot                { true }
     is_account_holder                 { true }
-    account_holder_name               { '' }
+    account_holder_name               { full_name }
     device_phone_number               { '07123 456789' }
     privacy_statement_sent_to_family  { true }
     understands_how_pii_will_be_used  { true }

--- a/spec/features/mno/mno_recipients_spec.rb
+++ b/spec/features/mno/mno_recipients_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature 'MNO Requests view', type: :feature do
 
     scenario 'shows only requests from my MNO' do
       expect(page).to have_content("Requests for data-cap-raises for #{mno_user.mobile_network.brand} customers")
-      expect(page).to have_content(recipient_for_mno.full_name)
-      expect(page).not_to have_content(recipient_for_other_mno.full_name)
+      expect(page).to have_content(recipient_for_mno.account_holder_name)
+      expect(page).not_to have_content(recipient_for_other_mno.account_holder_name)
     end
 
     scenario 'clicking Select All selects all checkboxes' do
@@ -63,11 +63,11 @@ RSpec.feature 'MNO Requests view', type: :feature do
     end
 
     scenario 'clicking on a header twice sorts by that column in reverse order' do
-      click_on 'Recipient name'
-      expect(rendered_ids).to eq(mno_recipients.order(:full_name).pluck(:id))
+      click_on 'Account holder'
+      expect(rendered_ids).to eq(mno_recipients.order(:account_holder_name).pluck(:id))
 
-      click_on 'Recipient name'
-      expect(rendered_ids).to eq(mno_recipients.order(full_name: :desc).pluck(:id))
+      click_on 'Account holder'
+      expect(rendered_ids).to eq(mno_recipients.order(account_holder_name: :desc).pluck(:id))
     end
 
     scenario 'updating selected recipients to a status applies that status' do


### PR DESCRIPTION
### Context

We should only give the MNOs the bare minimum PII they need in order to process the cap-lift. 

### Changes proposed in this pull request

Remove recipient name from MNO interface + CSV download
Populate account holder name for all recipients

<img width="842" alt="Screen Shot 2020-06-16 at 13 01 53" src="https://user-images.githubusercontent.com/134501/84771602-a20ce080-afd1-11ea-9072-a55bab2e31b4.png">

<img width="858" alt="Screen Shot 2020-06-16 at 13 02 02" src="https://user-images.githubusercontent.com/134501/84771633-acc77580-afd1-11ea-9660-c2d2b0e54e97.png">

### Guidance to review

